### PR TITLE
invalidating channel user list

### DIFF
--- a/frontend/app/src/components/global-components/navbar.tsx
+++ b/frontend/app/src/components/global-components/navbar.tsx
@@ -24,6 +24,7 @@ function Navbar({ text, avatarImg }: BannerProps) {
   const currentLocation = useLocation();
   const queryClient = useQueryClient();
   const friendsListQueryKey = 'friendsList';
+  const channelUsersQueryKey = 'channelUsers';
 
   const showInfo = () => {
     setIsShown((current) => !current);
@@ -40,15 +41,19 @@ function Navbar({ text, avatarImg }: BannerProps) {
     }
     socket.on('userDisconnected', () => {
       void queryClient.invalidateQueries(friendsListQueryKey);
+      void queryClient.invalidateQueries(channelUsersQueryKey);
     });
     socket.on('userConnected', (): void => {
       void queryClient.invalidateQueries(friendsListQueryKey);
+      void queryClient.invalidateQueries(channelUsersQueryKey);
     });
     socket.on('userInGame', (): void => {
       void queryClient.invalidateQueries(friendsListQueryKey);
+      void queryClient.invalidateQueries(channelUsersQueryKey);
     });
     socket.on('userGameEnded', (): void => {
       void queryClient.invalidateQueries(friendsListQueryKey);
+      void queryClient.invalidateQueries(channelUsersQueryKey);
     });
     return () => {
       socket.off('userDisconnected');


### PR DESCRIPTION
# Description

Navbar was missing cache invalidation for channel users, so the connection status would not update in chat when a user ended a game or on any other event

# Changes include

- [ ] New feature (non-breaking change that adds functionality)
- [x] Bugfix (non-breaking change that solves an issue)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the needed labels
- [ ] I have linked this PR to an issue
- [ ] I have linked this PR to a milestone
- [ ] I have linked this PR to a project
- [ ] I have tested this code
- [ ] I have added / updated tests (unit / functionals / end-to-end / ...)
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
