### PR TITLE
fix(achievement): display achievement depending on window size

### DIFF
--- a/frontend/app/src/components/custom-hooks/use-window-dimension.tsx
+++ b/frontend/app/src/components/custom-hooks/use-window-dimension.tsx
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react';
+
+export function getWindowDimensions() {
+  const { innerWidth: width, innerHeight: height } = window;
+  return {
+    width,
+    height,
+  };
+}
+
+export default function useWindowDimensions() {
+  const [windowDimensions, setWindowDimensions] = useState(
+    getWindowDimensions(),
+  );
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowDimensions(getWindowDimensions());
+    }
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return windowDimensions;
+}

--- a/frontend/app/src/components/section-components/chat/channel-options.tsx
+++ b/frontend/app/src/components/section-components/chat/channel-options.tsx
@@ -28,7 +28,6 @@ function ChannelOptions({
 
   //   const channelsQueryKey = 'channelsByUserList';
   // const userQueryKey = 'userData';
-  const channelsQueryKey = 'channelsByUserList';
   const [showEditModal, setShowEditModal] = useState<boolean>(false);
   const [showInviteModal, setShowInviteModal] = useState<boolean>(false);
 
@@ -85,7 +84,7 @@ function ChannelOptions({
           </p>
         </Link>
         {myRoleQueryData?.role === channelRole.Owner &&
-          channelInfo.type !== channelType.DirectMessage ? (
+        channelInfo.type !== channelType.DirectMessage ? (
           <div className="z-40">
             <div onClick={handleEditModal}>
               <p className="text-center hover:underline my-2">Edit channel</p>
@@ -103,7 +102,7 @@ function ChannelOptions({
         ) : null}
         {(myRoleQueryData?.role === channelRole.Owner ||
           myRoleQueryData?.role === channelRole.Admin) &&
-          channelInfo.type === channelType.Private ? (
+        channelInfo.type === channelType.Private ? (
           <div className="z-40">
             <div onClick={handleInviteModal}>
               <p className="text-center hover:underline my-2">Invite members</p>

--- a/frontend/app/src/components/section-components/profile/achievement.tsx
+++ b/frontend/app/src/components/section-components/profile/achievement.tsx
@@ -47,7 +47,6 @@ function SelectedAchievement({
 }: AchievementModalProps) {
   const [showModal, setShowModal] = useState<boolean>(false);
   const { width } = useWindowDimensions();
-  console.log(width);
 
   function ShowAchievementInfo() {
     setShowModal((current) => !current);

--- a/frontend/app/src/components/section-components/profile/achievement.tsx
+++ b/frontend/app/src/components/section-components/profile/achievement.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { UseOutsideClick } from 'src/components/custom-hooks/use-outside-click';
+import useWindowDimensions from 'src/components/custom-hooks/use-window-dimension';
 import { AchievementData } from 'src/components/global-components/interface';
 import useUserAchievements from 'src/components/query-hooks/useUserAchievements';
 import LoadingSpinner from '../loading-spinner';
@@ -45,6 +46,8 @@ function SelectedAchievement({
   nickname,
 }: AchievementModalProps) {
   const [showModal, setShowModal] = useState<boolean>(false);
+  const { width } = useWindowDimensions();
+  console.log(width);
 
   function ShowAchievementInfo() {
     setShowModal((current) => !current);
@@ -58,13 +61,22 @@ function SelectedAchievement({
 
   return (
     <div ref={ref}>
-      <img
-        className="w-8 h-8 sm:w-9 sm:h-9 md:w-10 md:h-10 lg:w-12 lg:h-12 xl:w-14 xl:h-14 rounded-full cursor-pointer"
-        src={achievementData.image}
-        alt="Rounded achievement"
-        onMouseEnter={ShowAchievementInfo}
-        onMouseLeave={ShowAchievementInfo}
-      />
+      {width > 1093 ? (
+        <img
+          className="w-8 h-8 sm:w-9 sm:h-9 md:w-10 md:h-10 lg:w-12 lg:h-12 xl:w-14 xl:h-14 rounded-full cursor-pointer"
+          src={achievementData.image}
+          alt="Rounded achievement"
+          onMouseEnter={ShowAchievementInfo}
+          onMouseLeave={ShowAchievementInfo}
+        />
+      ) : (
+        <img
+          className="w-8 h-8 sm:w-9 sm:h-9 md:w-10 md:h-10 lg:w-12 lg:h-12 xl:w-14 xl:h-14 rounded-full cursor-pointer"
+          src={achievementData.image}
+          alt="Rounded achievement"
+          onClick={ShowAchievementInfo}
+        />
+      )}
       <div>
         {showModal && (
           <AchievementModal


### PR DESCRIPTION
# Description

Added a useWindowDimension to get the size of the screen. Achievement will be displayed on click or on hover accordingly

# Changes include

- [ ] New feature (non-breaking change that adds functionality)
- [X] Bugfix (non-breaking change that solves an issue)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the needed labels
- [X] I have linked this PR to an issue
- [X] I have linked this PR to a milestone
- [X] I have linked this PR to a project
- [X] I have tested this code
- [ ] I have added / updated tests (unit / functionals / end-to-end / ...)
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs

