### PR TITLE
fix for 404 displaying when creating / joining a channel

### DIFF
--- a/backend/app/src/channel/channel.service.ts
+++ b/backend/app/src/channel/channel.service.ts
@@ -197,7 +197,7 @@ export class ChannelService {
       }
       return flattenUsers;
     } catch (error) {
-      if (error.status === 404) throw new NotFoundException(error);
+      if (error.status === 404) return undefined;
       else throw new ForbiddenException(error);
     }
   }

--- a/frontend/app/src/components/global-components/chat.tsx
+++ b/frontend/app/src/components/global-components/chat.tsx
@@ -172,18 +172,19 @@ function Chat() {
   }, [activeChannelId, socket, user, channels.data?.length, queryClient]);
 
   /** Fallback on 404 when the channel is not accessible (not invited, not existing) */
-  if (activeChannel) {
-    if (
-      channels.data &&
-      !channels.data.find((channel) => channel.id === activeChannel)
-    )
-      return <PageNotFound />;
+  let displayChannel = true;
+  if (activeChannel && channels.data) {
+    const foundChannel = channels.data.find((channel) => channel.id === activeChannel);
+    if (foundChannel === undefined)
+      displayChannel = false;
   }
+
 
   return (
     <>
       {user.isLoading && <LoadingSpinner />}
-      {user.isSuccess && (
+      {!displayChannel && channels.data && channels.data.length > 0 && <PageNotFound />}
+      {displayChannel && user.isSuccess && (
         <div className="h-full min-h-screen bg-black z-0">
           <Navbar
             text={<FontAwesomeIcon icon={faHouse} />}


### PR DESCRIPTION
# Description

When the user has no channel joined (channels.data is empty), then we will redirect to /chat (not the 404 component)
When the user as already joined channels, we will display the 404 component as it would generate a white buggy page instead.

# Changes include

- [ ] New feature (non-breaking change that adds functionality)
- [X] Bugfix (non-breaking change that solves an issue)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it.

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have added the needed labels
- [X] I have linked this PR to an issue
- [X] I have linked this PR to a milestone
- [X] I have linked this PR to a project
- [X] I have tested this code
- [ ] I have added / updated tests (unit / functionals / end-to-end / ...)
- [ ] I have updated the README and other relevant documents (guides...)
- [ ] I have added sufficient documentation both in code, as well as in the READMEs

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
